### PR TITLE
Add Database Configuration Options

### DIFF
--- a/roles/drupal/defaults/main.yml
+++ b/roles/drupal/defaults/main.yml
@@ -6,10 +6,13 @@ drupal_trusted_host_patterns: ''
 files_pvc_size: 1Gi
 
 # Database options (will be used regardless of database location).
+database_driver: mysql
 database_name: drupal
 database_username: drupal
 database_password: drupal
+database_prefix: ''
 database_host: 'example-drupal-mariadb'
+database_port: 3306
 
 # Set this to 'true' to use a single-pod database managed by this operator.
 manage_database: true

--- a/roles/drupal/tasks/main.yml
+++ b/roles/drupal/tasks/main.yml
@@ -15,11 +15,11 @@
             'database' => '{{ database_name }}',
             'username' => '{{ database_username }}',
             'password' => '{{ database_password }}',
-            'prefix' => '',
+            'prefix' => '{{ database_prefix }}',
             'host' => '{{ database_host }}',
-            'port' => '3306',
-            'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-            'driver' => 'mysql',
+            'port' => '{{ database_port }}',
+            'namespace' => 'Drupal\\Core\\Database\\Driver\\{{ database_driver }}',
+            'driver' => '{{ database_driver }}',
           );
 
           $settings['hash_salt'] = '{{ drupal_hash_salt | default(lookup('password', '/dev/null chars=ascii_letters'), true) }}';


### PR DESCRIPTION
This adds the rest of the Database Configuration from settings.php
into the defaults main variables.

  * database_driver (default mysql)
  * database_port (default 3306)
  * database_prefix (default '')

Signed-off-by: David Brown <dmlb2000@gmail.com>